### PR TITLE
Fix ClassCastException in CTArtisanRecipe

### DIFF
--- a/src/main/java/com/codetaylor/mc/artisanworktables/modules/worktables/integration/crafttweaker/CTArtisanRecipe.java
+++ b/src/main/java/com/codetaylor/mc/artisanworktables/modules/worktables/integration/crafttweaker/CTArtisanRecipe.java
@@ -315,11 +315,10 @@ public class CTArtisanRecipe
     IItemStack[] stacks = this.getStacksShapeless(context).getStacks();
 
     for (int i = 0; i < ingredients.size(); i++) {
-      IArtisanIngredient artisanIngredient = ingredients.get(i);
+      IArtisanIngredient ingredient = ingredients.get(i);
 
-      if (!artisanIngredient.isEmpty()) {
-        CTArtisanIngredient ingredient = (CTArtisanIngredient) artisanIngredient;
-        String mark = ingredient.getIngredient().getMark();
+      if (ingredient instanceof CTArtisanIngredient) {
+        String mark = ((CTArtisanIngredient) ingredient).getIngredient().getMark();
 
         if (mark != null) {
           marks.put(mark, stacks[i]);
@@ -334,11 +333,10 @@ public class CTArtisanRecipe
     IItemStack[] stacks = this.getStacksShaped(context).getStacks();
 
     for (int i = 0; i < ingredients.size(); i++) {
-      IArtisanIngredient artisanIngredient = ingredients.get(i);
+      IArtisanIngredient ingredient = ingredients.get(i);
 
-      if (!artisanIngredient.isEmpty()) {
-        CTArtisanIngredient ctArtisanIngredient = (CTArtisanIngredient) artisanIngredient;
-        String mark = ctArtisanIngredient.getIngredient().getMark();
+      if (ingredient instanceof CTArtisanIngredient) {
+        String mark = ((CTArtisanIngredient) ingredient).getIngredient().getMark();
 
         if (mark != null) {
           marks.put(mark, stacks[i]);


### PR DESCRIPTION
Should fix the following `ClassCastException` in `CTArtisanRecipe.getMarksShaped` and `.getMarksShapeless` I ran into. Other methods appear to account for cases where the ingredient is not a `CTArtisanIngredient`. Unfortunately, I don't really have the knowledge to understand the whole codebase, but I figure you can verify whether this change is necessary.

```
java.lang.ClassCastException: com.codetaylor.mc.artisanworktables.api.internal.recipe.ArtisanIngredient cannot be cast to com.codetaylor.mc.artisanworktables.modules.worktables.integration.crafttweaker.CTArtisanIngredient
	at com.codetaylor.mc.artisanworktables.modules.worktables.integration.crafttweaker.CTArtisanRecipe.getMarksShapeless(CTArtisanRecipe.java:321)
	at com.codetaylor.mc.artisanworktables.modules.worktables.integration.crafttweaker.CTArtisanRecipe.processRecipeFunction(CTArtisanRecipe.java:217)
	at com.codetaylor.mc.artisanworktables.modules.worktables.integration.crafttweaker.CTArtisanRecipe.getBaseOutput(CTArtisanRecipe.java:94)
	at com.codetaylor.mc.artisanworktables.modules.worktables.gui.AWContainer.updateRecipeOutput(AWContainer.java:476)
	at com.codetaylor.mc.artisanworktables.modules.worktables.tile.spi.TileEntityBase.triggerContainerRecipeUpdate(TileEntityBase.java:202)
	at com.codetaylor.mc.artisanworktables.modules.worktables.tile.spi.TileEntityBase.func_189517_E_(TileEntityBase.java:441)
	at com.codetaylor.mc.artisanworktables.modules.worktables.tile.spi.TileEntityBase.func_189518_D_(TileEntityBase.java:428)
	at net.minecraft.server.management.PlayerChunkMapEntry.func_187273_a(PlayerChunkMapEntry.java:288)
	at net.minecraft.server.management.PlayerChunkMapEntry.func_187280_d(PlayerChunkMapEntry.java:250)
	at net.minecraft.server.management.PlayerChunkMap.func_72693_b(SourceFile:115)
	at net.minecraft.world.WorldServer.func_72835_b(WorldServer.java:227)
	at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:756)
	at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:668)
	at net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:185)
	at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:526)
	at java.lang.Thread.run(Thread.java:748)
```

(I'm still struggling with making Vanilla CT crafting recipes work in tables - getting "Error executing RecipeFunction" and different crafting results than in Vanilla crafting tables - and might give up after this and just disable Vanilla crafting in Artisan Worktables.)