### PR TITLE
Modify IToolHandler to allow returning any result ItemStack

### DIFF
--- a/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/DefaultToolHandler.java
+++ b/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/DefaultToolHandler.java
@@ -25,26 +25,20 @@ public class DefaultToolHandler
   }
 
   @Override
-  public boolean canAcceptAllDamage(ItemStack itemStack, int damage) {
+  public boolean canApplyUses(ItemStack itemStack, int uses, boolean restrictDurability) {
 
-    return (itemStack.getItemDamage() + damage <= itemStack.getMaxDamage());
+    return !restrictDurability || (itemStack.getItemDamage() + uses <= itemStack.getMaxDamage());
   }
 
   @Override
-  public boolean applyDamage(World world, ItemStack itemStack, int damage, @Nullable EntityPlayer player, boolean simulate) {
+  public ItemStack applyUses(World world, ItemStack itemStack, int uses, @Nullable EntityPlayer player) {
 
-    if (simulate) {
-      return (itemStack.getItemDamage() + damage > itemStack.getMaxDamage());
-
-    } else {
-      boolean broken = itemStack.attemptDamageItem(damage, new Random(), null)
-          || itemStack.getItemDamage() == itemStack.getMaxDamage();
-
-      if (broken) {
-        itemStack.shrink(1);
-      }
-
-      return broken;
+    ItemStack result = itemStack.copy();
+    boolean broken = itemStack.attemptDamageItem(uses, new Random(), null)
+        || itemStack.getItemDamage() == itemStack.getMaxDamage();
+    if (broken) {
+      itemStack.shrink(1);
     }
+    return result;
   }
 }

--- a/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/IArtisanRecipe.java
+++ b/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/IArtisanRecipe.java
@@ -91,9 +91,9 @@ public interface IArtisanRecipe {
   /**
    * @param handler
    * @param tool    the tool to check
-   * @return true if the given tool has sufficient durability to complete the craft
+   * @return true if the given tool has sufficient uses to complete the craft
    */
-  boolean hasSufficientToolDurability(IToolHandler handler, ItemStack tool);
+  boolean hasSufficientUses(IToolHandler handler, ItemStack tool);
 
   /**
    * @param tier the tier to match

--- a/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/IToolHandler.java
+++ b/src/api/java/com/codetaylor/mc/artisanworktables/api/recipe/IToolHandler.java
@@ -22,20 +22,20 @@ public interface IToolHandler {
   boolean matches(ItemStack tool, ItemStack toolToMatch);
 
   /**
-   * @param itemStack the tool
-   * @param damage    the damage to be applied to the tool
-   * @return true if the tool can accept all given damage
+   * @param itemStack          the tool
+   * @param uses               the number of uses that would be applied to the tool
+   * @param restrictDurability if true, must have sufficient durability remaining
+   * @return true if the tool can apply all the uses
    */
-  boolean canAcceptAllDamage(ItemStack itemStack, int damage);
+  boolean canApplyUses(ItemStack itemStack, int uses, boolean restrictDurability);
 
   /**
    * @param world
    * @param itemStack the tool
-   * @param damage    the damage
+   * @param uses      the number of uses to be applied to the tool
    * @param player
-   * @param simulate  if true, no damage will actually be applied
-   * @return true if the tool is broken as a result of the applied damage
+   * @return a new stack representing the item after the uses have been applied (usually in the form of item damage)
    */
-  boolean applyDamage(World world, ItemStack itemStack, int damage, @Nullable EntityPlayer player, boolean simulate);
+  ItemStack applyUses(World world, ItemStack itemStack, int uses, @Nullable EntityPlayer player);
 
 }


### PR DESCRIPTION
These changes would allow custom tools to return alternative `ItemStack`s as they're being used in Artisan Worktables. For example, I wanted to implement a [bucket of clay](https://github.com/copygirl/HardcoreBytesMod/blob/8da5861d8e6ba8f2bdd7bde104ddeb9af5a5e71b/src/main/java/net/mcft/copy/hardcorebytesmod/item/ItemBucketOfClay.java#L98-L122) that would work as a tool, which simply turns into an empty bucket when used up, rather than being broken.

- This is a breaking change. I haven't looked into whether default interface implementations could resolve this. I have not found anyone using this API yet, so it might not be a big deal?
- I changed some (but not all) of the method names involved to make the changes more clear. I have a feeling the names aren't the best they could be, though.
- No idea how this would or could be handled by automatic tool replacements, like when using Artisan Automation.
- `canApplyUses` accepts the `restrictCraftMinimumDurability` config setting, so tools can choose whether it applies to them. (In the "bucket of clay" example, it would not make sense to allow a recipe that requires 4 uses to be craftable when there's only 1 unit of clay available.)

This isn't really a finished pull request - I suppose it's more of a feature suggestion. However, since I have already done this to allow me to use a custom build of Artisan Worktables in my modpack, I figured I'd present it in this way. Better than making a regular issue I'd have to wait on - or for the request never to be implemented.